### PR TITLE
Add missing `vol_diff` key to BinaryPairwiseMeasures.measures_dict

### DIFF
--- a/MetricsReloaded/metrics/pairwise_measures.py
+++ b/MetricsReloaded/metrics/pairwise_measures.py
@@ -272,6 +272,7 @@ class BinaryPairwiseMeasures(object):
             "hd_perc": (self.measured_hausdorff_distance_perc, "HDPerc"),
             "masd": (self.measured_masd, "MASD"),
             "nsd": (self.normalised_surface_distance, "NSD"),
+            "vol_diff": (self.vol_diff, "VolDiff"),
         }
 
         self.pred = pred


### PR DESCRIPTION
This PR adds missing `vol_diff` key to [BinaryPairwiseMeasures.measures_dict](https://github.com/Project-MONAI/MetricsReloaded/blob/b3a371503f8417839d67b073732170ac01ed03f7/MetricsReloaded/metrics/pairwise_measures.py#L251)

Otherwise, the following KeyError is raised:

```console
Traceback (most recent call last):
  File "/Users/user/code/MetricsReloaded/MetricsReloaded/metrics/pairwise_measures.py", line 1161, in to_dict_meas
    if len(self.measures_dict[key]) == 2:
KeyError: 'vol_diff'
```

@p-j-smith, @csudre, could you please review this PR? 