### PR TITLE
Remove leftover print statement

### DIFF
--- a/MetricsReloaded/metrics/pairwise_measures.py
+++ b/MetricsReloaded/metrics/pairwise_measures.py
@@ -1071,7 +1071,7 @@ Pattern Recognition. 15334–15342.
             ref_border,
             pred_border,
         ) = self.border_distance()
-        print(ref_border_dist)
+        
         average_distance = (np.sum(ref_border_dist) + np.sum(pred_border_dist)) / (
             np.sum(pred_border + ref_border)
         )


### PR DESCRIPTION
Every time I use measured_distance(), it prints out the full array. This one line change removes the print statement which was presumably left in by mistake. 