### PR TITLE
Updating setup.py to address pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@
 import os
 from glob import glob
 
-from pkg_resources import parse_requirements
+#from pkg_resources import parse_requirements
+from packaging.requirements import Requirement
 from setuptools import find_packages
 from setuptools import setup
 
@@ -17,7 +18,10 @@ with open(os.path.join(source_dir, "MetricsReloaded/_version.py")) as o:
 
 # read install requirements from requirements.txt
 with open(os.path.join(source_dir, "requirements.txt")) as o:
-    requirements = [str(r) for r in parse_requirements(o.read())]
+    #requirements = {str(r).rstrip() for r in o}
+    requirements = o.read().splitlines()
+
+print(requirements)
 
 setup(
     name="MetricsReloaded",
@@ -25,7 +29,7 @@ setup(
     description=version_info["__description__"],
     author=version_info["__author__"],
     author_email=version_info["__author_email__"],
-    url="https://github.com/csudre/MetricsReloaded",
+    url="https://github.com/Project-MONAI/MetricsReloaded",
     packages=find_packages(),
     py_modules=[
         os.path.splitext(os.path.basename(path))[0]
@@ -46,14 +50,18 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
     ],
     project_urls={
         "Documentation": "https://MetricsReloaded.readthedocs.io/",
-        "Issue Tracker": "https://github.com/csudre/MetricsReloaded/issues",
+        "Issue Tracker": "https://github.com/Project-MONAI/MetricsReloaded/issues",
     },
     python_requires=">=3.7",
     install_requires=requirements,
+    extras_require={},
     setup_requires=[
         "pytest-runner",
     ],


### PR DESCRIPTION
Fixes #59.

This PR copies the state of `setup.py` from the `docs-test` branch to address the issue with `pkg_resouces` being missing. This passed tests in that branch so would be expected the valid fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project and issue-tracker links to the current repository.
  * Added Python 3.11, 3.12, and 3.13 to the supported-version metadata.
  * Improved handling of installation requirements during package setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->